### PR TITLE
To make binaries valid for submittal to Apple Notary.

### DIFF
--- a/src/cmd/link/internal/ld/macho.go
+++ b/src/cmd/link/internal/ld/macho.go
@@ -662,9 +662,13 @@ func Asmbmacho(ctxt *Link) {
 		// and we can assume OS X.
 		//
 		// See golang.org/issues/12941.
+                //
+                // For Apple Notary compatibility, the minimum version is 10.9.x.
+                //
+                // See golang.org/issues/30488.
 		ml := newMachoLoad(ctxt.Arch, LC_VERSION_MIN_MACOSX, 2)
-		ml.data[0] = 10<<16 | 7<<8 | 0<<0 // OS X version 10.7.0
-		ml.data[1] = 10<<16 | 7<<8 | 0<<0 // SDK 10.7.0
+		ml.data[0] = 10<<16 | 9<<8 | 0<<0 // OS X version 10.9.0
+		ml.data[1] = 10<<16 | 9<<8 | 0<<0 // SDK 10.9.0
 	}
 
 	a := machowrite(ctxt.Arch, ctxt.Out, ctxt.LinkMode)


### PR DESCRIPTION
This fixes #30488 how Go binaries would be otherwise be
ineligible for Apple Notary. The minimum SDK version used within is
version 10.9.